### PR TITLE
[FIX] 퀴즈 화면 반응형 처리 및 글자수 제한

### DIFF
--- a/app/src/main/java/com/tongueeye/wordcard/MainActivity.kt
+++ b/app/src/main/java/com/tongueeye/wordcard/MainActivity.kt
@@ -5,22 +5,13 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.provider.MediaStore
 import android.speech.tts.TextToSpeech
 import android.text.Editable
 import android.text.TextWatcher
-import android.util.Log
 import android.view.LayoutInflater
-import com.google.android.material.snackbar.Snackbar
 import androidx.appcompat.app.AppCompatActivity
-import androidx.navigation.findNavController
-import androidx.navigation.ui.AppBarConfiguration
-import androidx.navigation.ui.navigateUp
-import androidx.navigation.ui.setupActionBarWithNavController
-import android.view.Menu
-import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
@@ -126,7 +117,7 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             }
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 // 변경 중
-                dialogBinding.qtextCountTV.text="(${s?.length}자/100자)"
+                dialogBinding.qtextCountTV.text="(${s?.length}자/30자)"
             }
             override fun afterTextChanged(s: Editable?) {
             }
@@ -294,13 +285,13 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
             DELETE_IMAGE_CHECK = 1
         }
 
-        dialogBinding.qtextCountTV.text="(${dialogBinding.quizEditText.text.length}자/100자)"
+        dialogBinding.qtextCountTV.text="(${dialogBinding.quizEditText.text.length}자/30자)"
         dialogBinding.quizEditText.addTextChangedListener(object: TextWatcher{
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
             }
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 // 변경 중
-                dialogBinding.qtextCountTV.text="(${s?.length}자/100자)"
+                dialogBinding.qtextCountTV.text="(${s?.length}자/30자)"
             }
             override fun afterTextChanged(s: Editable?) {
             }
@@ -455,7 +446,5 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         }
         dialog.show()
     }
-
-
 
 }

--- a/app/src/main/res/layout/activity_play_quiz.xml
+++ b/app/src/main/res/layout/activity_play_quiz.xml
@@ -6,128 +6,155 @@
     android:layout_height="match_parent"
     android:background="@color/dark_night">
 
+    <!-- 배경 이미지 -->
     <ImageView
         android:id="@+id/play_quiz_bottom"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         android:scaleType="centerCrop"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintDimensionRatio="2.2:1"
+        app:layout_constraintHeight_percent="0.4"
         app:srcCompat="@drawable/splash_bottom" />
 
+    <!-- 중앙 버튼 -->
     <ImageView
         android:id="@+id/devil_check_btn"
-        android:layout_width="100dp"
-        android:layout_height="100dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toTopOf="@+id/quiz_paper_IV"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.501"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintHeight_percent="0.15"
+        app:layout_constraintWidth_percent="0.2"
         app:srcCompat="@drawable/devil_icon" />
 
+    <!-- 대화 상자 이미지 -->
     <ImageView
         android:id="@+id/dialog_IV"
-        android:layout_width="100dp"
-        android:layout_height="100dp"
-        android:layout_marginStart="8dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="@+id/devil_check_btn"
         app:layout_constraintStart_toEndOf="@+id/devil_check_btn"
+        app:layout_constraintHeight_percent="0.15"
+        app:layout_constraintWidth_percent="0.15"
         app:srcCompat="@drawable/dialog" />
 
+    <!-- 대화 상자 텍스트 -->
     <TextView
         android:id="@+id/dialog_TV"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="16dp"
         android:fontFamily="@font/nexon_cart_gothic_bold"
         android:text="맞춰봐!"
-        android:textSize="18dp"
+        android:textSize="18sp"
         android:textAlignment="center"
         app:layout_constraintBottom_toBottomOf="@+id/dialog_IV"
         app:layout_constraintEnd_toEndOf="@+id/dialog_IV"
         app:layout_constraintStart_toEndOf="@+id/devil_check_btn"
         app:layout_constraintTop_toTopOf="@+id/dialog_IV" />
 
+    <!-- 문제 카드 배경 -->
     <ImageView
         android:id="@+id/quiz_paper_IV"
-        android:layout_width="290dp"
-        android:layout_height="435dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="@+id/play_quiz_bottom"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.65"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintWidth_percent="0.7"
         app:srcCompat="@drawable/quiz_card_paper" />
 
+    <!-- 좌측 버튼 -->
     <ImageView
         android:id="@+id/leftBtn"
-        android:layout_width="55dp"
-        android:layout_height="80dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="@+id/quiz_paper_IV"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/quiz_paper_IV"
+        app:layout_constraintHeight_percent="0.1"
+        app:layout_constraintWidth_percent="0.15"
         app:srcCompat="@drawable/arrow_left" />
 
+    <!-- 우측 버튼 -->
     <ImageView
         android:id="@+id/rightBtn"
-        android:layout_width="55dp"
-        android:layout_height="80dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="@+id/quiz_paper_IV"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/quiz_paper_IV"
+        app:layout_constraintHeight_percent="0.1"
+        app:layout_constraintWidth_percent="0.15"
         app:srcCompat="@drawable/arrow_right" />
 
+    <!-- 종료 버튼 -->
     <ImageView
         android:id="@+id/exit_btn"
-        android:layout_width="70dp"
-        android:layout_height="60dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:layout_marginStart="10dp"
-        android:layout_marginTop="16dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintHeight_percent="0.1"
+        app:layout_constraintWidth_percent="0.15"
         app:srcCompat="@drawable/exit_btn" />
+
+    <!-- 문제 텍스트 -->
+
+    <!-- 문제 이미지 -->
+
+    <!-- 음성 재생 버튼 텍스트 -->
 
     <TextView
         android:id="@+id/question_TV"
-        android:layout_width="230dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="35dp"
-        android:layout_marginEnd="4dp"
-        android:layout_marginBottom="8dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:fontFamily="@font/nexon_cart_gothic_medium"
         android:gravity="center"
-        android:text="문제"
+        android:text="단어나 문장을 입력하면 이렇게 보입니다."
         android:textAlignment="center"
-        android:textSize="20dp"
+        android:textSize="30sp"
+        android:paddingStart="20dp"
+        android:paddingEnd="20dp"
         app:layout_constraintBottom_toTopOf="@+id/tts_replay_TV"
         app:layout_constraintEnd_toEndOf="@+id/quiz_paper_IV"
+        app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="@+id/quiz_paper_IV"
-        app:layout_constraintTop_toBottomOf="@+id/question_IV" />
+        app:layout_constraintTop_toBottomOf="@+id/question_IV"
+        app:layout_constraintVertical_bias="0.5" />
 
     <ImageView
         android:id="@+id/question_IV"
-        android:layout_width="150dp"
-        android:layout_height="150dp"
-        android:layout_marginTop="50dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:scaleType="fitCenter"
         android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@+id/play_quiz_bottom"
         app:layout_constraintEnd_toEndOf="@+id/quiz_paper_IV"
+        app:layout_constraintHeight_percent="0.25"
+        app:layout_constraintHorizontal_bias="0.575"
         app:layout_constraintStart_toStartOf="@+id/quiz_paper_IV"
         app:layout_constraintTop_toBottomOf="@+id/devil_check_btn"
+        app:layout_constraintWidth_percent="0.5"
         app:srcCompat="@drawable/add_photo_white" />
 
     <TextView
         android:id="@+id/tts_replay_TV"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="35dp"
+        android:layout_marginBottom="120dp"
         android:fontFamily="@font/nexon_cart_gothic_bold"
         android:text="(음성 다시 듣기 버튼)"
-        android:textSize="18dp"
+        android:textSize="25sp"
         app:layout_constraintBottom_toBottomOf="@+id/quiz_paper_IV"
         app:layout_constraintEnd_toEndOf="@+id/quiz_paper_IV"
-        app:layout_constraintStart_toStartOf="@+id/quiz_paper_IV" />
-
+        app:layout_constraintStart_toStartOf="@+id/quiz_paper_IV"
+        app:layout_constraintTop_toTopOf="@+id/play_quiz_bottom"
+        app:layout_constraintVertical_bias="1.0" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/dialog_create_quiz.xml
+++ b/app/src/main/res/layout/dialog_create_quiz.xml
@@ -53,7 +53,7 @@
         android:inputType="text"
         android:textSize="23sp"
         android:maxLines="6"
-        android:maxLength="100" />
+        android:maxLength="30" />
 
     <TextView
         android:id="@+id/qtextCountTV"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">WordCard</string>
     <string name="QuizName">퀴즈 문제</string>
-    <string name="dialog_create_text_count">(0자/100자)</string>
+    <string name="dialog_create_text_count">(0자/30자)</string>
     <string name="cancel_text">취소</string>
     <string name="confirm_text">확인</string>
     <string name="question_cnt">(풀 문제/전체 문제)</string>


### PR DESCRIPTION
1. 퀴즈 화면 반응형 처리
 - 퀴즈 카드가 폰이나 태블릿에서 실행했을 때 알맞은 비율로 보이도록 수정
2. 글자 수 제한
 - 듣고 따라 말할 수 있는 한 문장 기준 30자로 입력 글자 수 제한