### PR TITLE
[FEAT] 속도 조절 기능 구현 완료

### DIFF
--- a/app/src/main/java/com/tongueeye/wordcard/AppDatabase.kt
+++ b/app/src/main/java/com/tongueeye/wordcard/AppDatabase.kt
@@ -4,12 +4,15 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteDatabase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 @Database(entities = [Quiz::class, Setting::class], version = 2)
 abstract class AppDatabase() : RoomDatabase() {
 
     abstract fun quizDao(): QuizDao
-
     abstract fun settingDao(): SettingDao
 
     companion object{
@@ -21,6 +24,14 @@ abstract class AppDatabase() : RoomDatabase() {
                     context.applicationContext,
                     AppDatabase::class.java,
                     "app_database")
+                    .addCallback(object : RoomDatabase.Callback() { // 데이터베이스 초기화 시 실행되는 콜백 추가
+                        override fun onCreate(db: SupportSQLiteDatabase) {
+                            super.onCreate(db)
+                            CoroutineScope(Dispatchers.IO).launch {
+                                INSTANCE?.settingDao()?.initSpeed() // 기본값 삽입
+                            }
+                        }
+                    })
                     .allowMainThreadQueries()
                     .build()
             }

--- a/app/src/main/java/com/tongueeye/wordcard/MainActivity.kt
+++ b/app/src/main/java/com/tongueeye/wordcard/MainActivity.kt
@@ -103,7 +103,6 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
     
     
     fun showSpeedSettingDialog(){
-        Toast.makeText(this,"속도 조절 팝업 등장하도록 구현", Toast.LENGTH_SHORT).show()
 
         settingDialogBinding = DialogSettingSpeedBinding.inflate(LayoutInflater.from(this))
         val dialogBuilder = AlertDialog.Builder(this)
@@ -113,14 +112,27 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
         // 다이얼로그 배경을 투명색으로 설정
         dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
 
+        // DB에서 현재 저장된 속도 값 가져오기
+        val settingDao = AppDatabase.getDatabase(applicationContext)?.settingDao()
+        var speedValue = settingDao?.getTtsSpeed() ?: 1.0f  // 기본값 1.0f
+
+        // UI에 현재 속도 반영
+        settingDialogBinding.quizEditText.setText(String.format("%.1f", speedValue))
+
         // 감소 버튼 클릭 시
         settingDialogBinding.decreaseBtn.setOnClickListener {
-            Toast.makeText(this, "감소 버튼 클릭 (-0.1)", Toast.LENGTH_SHORT).show()
+            if (speedValue > 0.5f) { // 최소 속도 제한
+                speedValue -= 0.1f
+                settingDialogBinding.quizEditText.setText(String.format("%.1f", speedValue))
+            }
         }
 
         // 증가 버튼 클릭 시
         settingDialogBinding.increaseBtn.setOnClickListener {
-            Toast.makeText(this, "증가 버튼 클릭 (+0.1)", Toast.LENGTH_SHORT).show()
+            if (speedValue < 2.0f) { // 최대 속도 제한
+                speedValue += 0.1f
+                settingDialogBinding.quizEditText.setText(String.format("%.1f", speedValue))
+            }
         }
 
         // 다이얼로그 내 버튼 클릭 이벤트 처리
@@ -130,7 +142,8 @@ class MainActivity : AppCompatActivity(), TextToSpeech.OnInitListener {
 
         settingDialogBinding.saveBtn.setOnClickListener {
             // 저장 버튼 클릭 시 처리할 작업 수행
-            Toast.makeText(this, "속도 저장 완료!", Toast.LENGTH_SHORT).show()
+            settingDao?.setTtsSpeed(speedValue)
+            Toast.makeText(this, "속도 저장 완료! ($speedValue)", Toast.LENGTH_SHORT).show()
             dialog.dismiss()
         }
         dialog.show()

--- a/app/src/main/java/com/tongueeye/wordcard/PlayQuizActivity.kt
+++ b/app/src/main/java/com/tongueeye/wordcard/PlayQuizActivity.kt
@@ -204,12 +204,16 @@ class PlayQuizActivity: AppCompatActivity(), TextToSpeech.OnInitListener {
 
     // 텍스트를 음성으로 변환하는 함수
     private fun speakOut(text: String) {
+
+        val settingDao = AppDatabase.getDatabase(applicationContext)?.settingDao()
+        var speedValue = settingDao?.getTtsSpeed() ?: 1.0f  // 기본값 1.0f
+
         if (isTTSInitialized) {
             // TTS 음성이 실행되기 전 글자색을 파란색으로 변경
             binding.questionTV.setTextColor(ContextCompat.getColor(this, R.color.change_color))
 
             // 목소리 속도 설정 (1.0은 기본 속도, 0.5는 절반 속도, 2.0은 2배 속도)
-            tts?.setSpeechRate(1.0f)
+            tts?.setSpeechRate(speedValue)
             // 목소리 크기(피치) 설정 (1.0은 기본 피치, 0.5는 낮은 피치, 2.0은 높은 피치)
             tts?.setPitch(1.0f)
 

--- a/app/src/main/java/com/tongueeye/wordcard/Setting.kt
+++ b/app/src/main/java/com/tongueeye/wordcard/Setting.kt
@@ -7,5 +7,5 @@ import androidx.room.PrimaryKey
 data class Setting(
     @PrimaryKey(autoGenerate = true)
     val sid: Int = 0,
-    var ttsSpeed: Float
+    var ttsSpeed: Float = 1.0f
 )

--- a/app/src/main/java/com/tongueeye/wordcard/SettingDao.kt
+++ b/app/src/main/java/com/tongueeye/wordcard/SettingDao.kt
@@ -2,14 +2,17 @@ package com.tongueeye.wordcard
 
 import androidx.room.Dao
 import androidx.room.Query
-import androidx.room.Update
 
 @Dao
 interface SettingDao {
+
     @Query("SELECT ttsSpeed FROM setting WHERE sid = 0")
     fun getTtsSpeed(): Float
 
     @Query("UPDATE setting SET ttsSpeed = :ttsSpeed WHERE sid = 0")
     fun setTtsSpeed(ttsSpeed: Float)
+
+    @Query("INSERT OR IGNORE INTO setting(sid, ttsSpeed) VALUES(0, 1.0)")
+    fun initSpeed() // 값이 없을 때만 기본값 삽입
 
 }

--- a/app/src/main/res/layout/dialog_setting_speed.xml
+++ b/app/src/main/res/layout/dialog_setting_speed.xml
@@ -57,7 +57,7 @@
             android:maxLength="30"
             android:focusable="false"
             android:clickable="false"
-            android:text="1.0"
+            android:text="0"
             android:labelFor="@+id/instructionTextView"
             android:inputType="none"/>
 


### PR DESCRIPTION
 1. 속도 조절 팝업 창
  - 증가, 감소 버튼 클릭 시 속도 0.1 단위로 변경
  - 최저 0.5, 최고 2.0으로 제한
 2. 속도 디폴트 값 설정
  - 최초 앱 설치 시 기본 속도 1.0으로 셋팅 되도록 구현
 3. TTS 음성 재생 시 사용자가 설정한 속도로 재생 되도록 구현
  - 설정 테이블에서 사용자가 저장한 속도 값 가져옴